### PR TITLE
update calling busted

### DIFF
--- a/luadist/dist1/eq0.lua
+++ b/luadist/dist1/eq0.lua
@@ -60,7 +60,7 @@ local fn = {
   --  unit test
   test_unit = function ()
     -- require "busted.runner"()
-    require 'busted.runner'({ batch = true })
+    require 'busted.runner'({ standalone = false, batch = true })
   end,
 }
 if (#arg>0) then


### PR DESCRIPTION
Busted 2.0.rc11-0 has the following main file:

> require 'busted.runner'({ standalone = false })

Previous Busted versions had batch = true instead of standalone = false.
Use both of them to be compatible with both Busted versions.
